### PR TITLE
Introducing the 'AccountSet' XRP Ledger transaction to xrp-commander tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ xrp escrow <create|release>
 xrp tx <find>
 ```
 
+### Account Settings
+
+```
+xrp account <domain|emailHash>
+```
+
 ## Contributing
 
 This lib has been intentionally designed for easy contribution. To add a command simply submit a PR that adds a new file in the `./src/commands/` folder.

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,0 +1,7 @@
+import { Argv } from 'yargs'
+
+export const command = 'account '
+export const describe = `Set a Domain and/or Avatar on your XRP ledger account`
+export const builder = (argv: Argv) => {
+  return argv.commandDir('account')
+}

--- a/src/commands/account/account-set-transaction.ts
+++ b/src/commands/account/account-set-transaction.ts
@@ -1,0 +1,13 @@
+import { api, getXrpAddressAndSecret, signSubmitVerify } from '../../utils/xrp'
+import { FormattedTransactionType } from 'ripple-lib';
+
+
+export async function AccountSet (fields :any): Promise<FormattedTransactionType> {
+
+  const { address, secret } = await getXrpAddressAndSecret();
+
+  const prepared = await (await api()).prepareSettings(address, fields);
+  console.log('AccountSet transaction prepared...');
+
+  return signSubmitVerify(prepared, secret);
+}

--- a/src/commands/account/account-set-transaction.ts
+++ b/src/commands/account/account-set-transaction.ts
@@ -2,7 +2,7 @@ import { api, getXrpAddressAndSecret, signSubmitVerify } from '../../utils/xrp'
 import { FormattedTransactionType } from 'ripple-lib';
 
 
-export async function AccountSet (fields :any): Promise<FormattedTransactionType> {
+export async function execute (fields :any): Promise<FormattedTransactionType> {
 
   const { address, secret } = await getXrpAddressAndSecret();
 

--- a/src/commands/account/domain.ts
+++ b/src/commands/account/domain.ts
@@ -1,0 +1,28 @@
+import { Options } from 'yargs'
+import { AccountSet } from './account-set-transaction';
+
+export type Params = {
+  domain?: string
+}
+export const command = 'domain [domain]'
+export const describe = `Sets a domain on the XRP ledger account. Leave empty to delete your domain.`
+export const builder: { [key: string]: Options } = {
+  domain: {
+    type: 'string',
+    required: false,
+    description: 'domain to set on your XRPL account'
+  }
+}
+
+export async function handler ({ domain }: Params) {
+
+  let result = await AccountSet({domain: domain ? domain : ''});
+
+  console.log(JSON.stringify(result, null, 2))
+  
+  if (result.outcome.result === 'tesSUCCESS') {
+    console.log('Domain set to: ' + domain)
+    process.exit(0)
+  }
+  process.exit(1)
+}

--- a/src/commands/account/domain.ts
+++ b/src/commands/account/domain.ts
@@ -1,5 +1,5 @@
 import { Options } from 'yargs'
-import { AccountSet } from './account-set-transaction';
+import * as accountSet from './account-set-transaction';
 
 export type Params = {
   domain?: string
@@ -16,12 +16,16 @@ export const builder: { [key: string]: Options } = {
 
 export async function handler ({ domain }: Params) {
 
-  let result = await AccountSet({domain: domain ? domain : ''});
+  let result = await accountSet.execute({domain: domain ? domain : ''});
 
   console.log(JSON.stringify(result, null, 2))
   
   if (result.outcome.result === 'tesSUCCESS') {
-    console.log('Domain set to: ' + domain)
+    if(domain)
+      console.log('\nDomain set to: ' + domain)
+    else
+      console.log('\nDomain deleted');
+      
     process.exit(0)
   }
   process.exit(1)

--- a/src/commands/account/email.ts
+++ b/src/commands/account/email.ts
@@ -1,0 +1,29 @@
+import { Options } from 'yargs'
+import { AccountSet } from './account-set-transaction';
+
+export type Params = {
+  emailHash?: string
+}
+export const command = 'email [email]'
+export const describe = `Sets an email for the XRP ledger account to show the avatar. Leave empty to delete avatar.`
+export const builder: { [key: string]: Options } = {
+  emailHash: {
+    type: 'string',
+    required: false,
+    description: 'emailHash to set on your XRPL account'
+  }
+}
+
+export async function handler ({ emailHash }: Params) {
+
+  let result = await AccountSet({emailHash: emailHash ? emailHash : ''});
+
+  console.log(JSON.stringify(result, null, 2))
+  
+  if (result.outcome.result === 'tesSUCCESS') {
+    console.log('emailHash set to: ' + emailHash)
+    process.exit(0)
+  }
+  process.exit(1)
+}
+

--- a/src/commands/account/emailHash.ts
+++ b/src/commands/account/emailHash.ts
@@ -1,27 +1,27 @@
 import { Options } from 'yargs'
-import { AccountSet } from './account-set-transaction';
+import * as accountSet from './account-set-transaction';
 
 export type Params = {
-  emailHash?: string
+  emailHash: string
 }
-export const command = 'email [email]'
-export const describe = `Sets an email for the XRP ledger account to show the avatar. Leave empty to delete avatar.`
+export const command = 'emailHash <emailHash>'
+export const describe = `Sets an emailHash on the XRP ledger account to show the avatar.`
 export const builder: { [key: string]: Options } = {
   emailHash: {
     type: 'string',
-    required: false,
+    required: true,
     description: 'emailHash to set on your XRPL account'
   }
 }
 
 export async function handler ({ emailHash }: Params) {
 
-  let result = await AccountSet({emailHash: emailHash ? emailHash : ''});
+  let result = await accountSet.execute({emailHash: emailHash});
 
   console.log(JSON.stringify(result, null, 2))
   
   if (result.outcome.result === 'tesSUCCESS') {
-    console.log('emailHash set to: ' + emailHash)
+    console.log('\nemailHash set to: ' + emailHash)
     process.exit(0)
   }
   process.exit(1)


### PR DESCRIPTION
This PR introduces the AccountSet XRPL transaction to the xrp-commander tool:
https://developers.ripple.com/accountset.html

With this change, it would be possible to add/remove a domain from an existing XRP Ledger account.

Additionaly it would be possible to set an 'emailHash' which could show an Avatar and other information:
"Hash of an email address to be used for generating an avatar image. Conventionally, clients use Gravatar to display this image."

Other AccountSet features are not implemented yet because changing these prameters could have a big negative impact on the exisiting XRP Leder account.