### PR TITLE
Implement balance command for XRP CLI

### DIFF
--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,0 +1,31 @@
+import { Command } from "../command";
+import RippleAPI from "ripple-lib";
+
+export default class Balance extends Command {
+  static description = "Check XRP balance of an address";
+
+  static args = [
+    {
+      name: "address",
+      required: true,
+      description: "XRP address to query",
+    },
+  ];
+
+  async run() {
+    const { args, env } = this;
+    const address = args.address;
+    const server = env.XRP_SERVER || "wss://s1.ripple.com:443";
+
+    const api = new RippleAPI({ server });
+
+    try {
+      await api.connect();
+      const info = await api.getAccountInfo(address);
+      console.log(`✅ Balance for ${address}: ${info.xrpBalance} XRP`);
+      await api.disconnect();
+    } catch (err) {
+      console.error(`❌ Error fetching balance: ${err.message}`);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new CLI command `xrp balance <address>` to XRP Commander.  
It connects to the XRP Ledger and prints the current XRP balance for the specified address.

**Usage example:**
$ xrp balance rEXAMPLEADDRESS12345
✅ Balance for rEXAMPLEADDRESS12345: 123.456 XRP

**Implementation details:**
- Uses ripple-lib
- Default server: wss://s1.ripple.com:443 (can be overridden with XRP_SERVER env)
- Async/await with proper error handling
- Fully compatible with existing CLI command structure

This closes #<issue_number>.
